### PR TITLE
fix public ip allocation for gpu nodes

### DIFF
--- a/k8s-inference/main.tf
+++ b/k8s-inference/main.tf
@@ -69,7 +69,7 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
     network_interfaces = [
       {
         subnet_id = var.subnet_id
-        public_ip = var.gpu_nodes_assign_public_ip ? {} : null
+        public_ip_address = var.gpu_nodes_assign_public_ip ? {} : null
       }
     ]
     resources = {

--- a/k8s-training/main.tf
+++ b/k8s-training/main.tf
@@ -69,7 +69,7 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
     network_interfaces = [
       {
         subnet_id = var.subnet_id
-        public_ip = var.gpu_nodes_assign_public_ip ? {} : null
+        public_ip_address = var.gpu_nodes_assign_public_ip ? {} : null
       }
     ]
     resources = {


### PR DESCRIPTION
 replace `public_ip` with `public_ip_address` in `k8s-inference` and `k8s-training`