### PR TITLE
Fix ubuntu username with ssh_user_name variable

### DIFF
--- a/slurm/files/cloud-config-master.yaml.tftpl
+++ b/slurm/files/cloud-config-master.yaml.tftpl
@@ -20,7 +20,7 @@ packages:
 runcmd:
   - mkdir -p /home/slurm
   - chmod 700 /home/slurm
-  - cp /home/ubuntu/.bashrc /home/slurm/
+  - cp /home/${ssh_user_name}/.bashrc /home/slurm/
   - cp /etc/ssh/id_rsa /home/slurm/.ssh/
   - chown -R slurm:slurm /home/slurm
   %{~ if shared_fs_type == "filesystem" ~}

--- a/slurm/slurm-master.tf
+++ b/slurm/slurm-master.tf
@@ -45,6 +45,7 @@ resource "nebius_compute_v1_instance" "master" {
       nfs_export_path       = var.shared_fs_type == "nfs" ? module.nfs-module[0].nfs_export_path : 0
       nfs_ip                = var.shared_fs_type == "nfs" ? module.nfs-module[0].nfs_server_internal_ip : 0
       is_mysql              = var.mysql_jobs_backend
+      ssh_user_name         = local.ssh_user_name
       ssh_public_key        = local.ssh_public_key
       cluster_workers_count = var.cluster_workers_count
       hostname              = "slurm-master"

--- a/wireguard/test-resource.tf
+++ b/wireguard/test-resource.tf
@@ -6,8 +6,10 @@ resource "null_resource" "check_wireguard_instance" {
   count = var.test_mode ? 1 : 0
 
   connection {
-    user = "ubuntu"
+    type = "ssh"
+    user = var.ssh_user_name
     host = local.test_wg_host
+    private_key = fileexists(replace(var.ssh_public_key.path, ".pub", "")) ? file(replace(var.ssh_public_key.path, ".pub", "")) : null
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
At least, default user name could change to something like `nebius` 🤗 

Kindly review if it can suits (terraform test of wireguard is more complicated since involving ssh private key detection, but why not - tested with below configuration)

```
...
ssh_public_key = {
# key  = "put your public ssh key here" OR
  path = "~/.ssh/id_nebius.pub"
}
...
```