### PR TITLE
[ADD] Set GPU Operator driver version to 550.127.08

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -181,6 +181,7 @@ module "nvidia_operator_gpu" {
 
   cluster_id = module.k8s.cluster_id
   parent_id  = data.nebius_iam_v1_project.this.id
+  driver_version = "550.127.08"
 
   enable_dcgm_service_monitor = var.telemetry_enabled
 


### PR DESCRIPTION
"For Soperator, it’s better to set the default to this new value 550.127.08 and periodically update it manually, because for some version upgrades we also need to upgrade the CUDA version." (c) Mikhail Mokrushin