### PR TITLE
MSP-3518: add slurmdbd_config and slurm_config configurable

### DIFF
--- a/soperator/.gitignore
+++ b/soperator/.gitignore
@@ -1,2 +1,3 @@
 .terraform*
 installations/alexkim
+installations/pikachu

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -565,13 +565,41 @@ variable "accounting_enabled" {
 variable "slurmdbd_config" {
   description = "Slurmdbd.conf configuration. See https://slurm.schedmd.com/slurmdbd.conf.html.Not all options are supported."
   type        = map(any)
-  default     = {}
+  default = {
+    # archiveEvents : "yes"
+    # archiveJobs : "yes"
+    # archiveSteps : "yes"
+    # archiveSuspend : "yes"
+    # archiveResv : "yes"
+    # archiveUsage : "yes"
+    # archiveTXN : "yes"
+    # debugLevel : "info"
+    # tcpTimeout : 120
+    # purgeEventAfter : "1month"
+    # purgeJobAfter : "1month"
+    # purgeStepAfter : "1month"
+    # purgeSuspendAfter : "12month"
+    # purgeResvAfter : "1month"
+    # purgeUsageAfter : "1month"
+    # debugFlags : "DB_ARCHIVE"
+  }
 }
 
 variable "slurm_accounting_config" {
   description = "Slurm.conf accounting configuration. See https://slurm.schedmd.com/slurm.conf.html. Not all options are supported."
   type        = map(any)
-  default     = {}
+  default = {
+    # accountingStorageTRES: "gres/gpu,license/iop1"
+    # accountingStoreFlags: "job_comment,job_env,job_extra,job_script,no_stdio"
+    # acctGatherInterconnectType: "acct_gather_interconnect/ofed"
+    # acctGatherFilesystemType: "acct_gather_filesystem/lustre"
+    # jobAcctGatherType: "jobacct_gather/cgroup"
+    # jobAcctGatherFrequency: 30
+    # priorityWeightAge: 1
+    # priorityWeightFairshare: 1
+    # priorityWeightQOS: 1
+    # priorityWeightTRES: 1
+  }
 }
 
 # endregion Accounting

--- a/soperator/modules/slurm/templates/helm_values/slurm_cluster.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/slurm_cluster.yaml.tftpl
@@ -177,13 +177,13 @@ slurmNodes:
     %{~ if length(nodes.accounting.slurmdbd_config) > 0 ~}
     slurmdbdConfig:
       %{~ for key, value in nodes.accounting.slurmdbd_config ~}
-      ${key}: "${value}"
+      ${key}: %{ if value == "yes" || value == "no" }"${value}"%{ else }${value}%{ endif }
       %{~ endfor ~}
     %{~ endif ~}
     %{~ if length(nodes.accounting.slurm_config) > 0 ~}
     slurmConfig:
       %{~ for key, value in nodes.accounting.slurm_config ~}
-      ${key}: "${value}"
+      ${key}: %{ if value == "yes" || value == "no" }"${value}"%{ else }${value}%{ endif }
       %{~ endfor ~}
     %{~ endif ~}
     slurmdbd:


### PR DESCRIPTION
Since when deploying through Terraform, the values `yes` and `no` are treated as booleans rather than strings, a workaround has been implemented to check these values and wrap them in quotes, thereby converting them into strings instead of booleans.