### PR TITLE
fix: minimal fixes for eu-west1

### DIFF
--- a/slurm/files/cloud-config-master.yaml.tftpl
+++ b/slurm/files/cloud-config-master.yaml.tftpl
@@ -18,6 +18,7 @@ packages:
   %{~ endif ~}
 
 runcmd:
+  - hostname slurm-master
   - mkdir -p /home/slurm
   - chmod 700 /home/slurm
   - cp /home/ubuntu/.bashrc /home/slurm/

--- a/slurm/gpu_cluster.tf
+++ b/slurm/gpu_cluster.tf
@@ -2,5 +2,5 @@
 resource "nebius_compute_v1_gpu_cluster" "gpu-cluster-slurm" {
   parent_id         = var.parent_id
   name              = "gpu-cluster-slurm"
-  infiniband_fabric = "fabric-3"
+  infiniband_fabric = "fabric-5"
 }

--- a/slurm/gpu_cluster.tf
+++ b/slurm/gpu_cluster.tf
@@ -2,5 +2,6 @@
 resource "nebius_compute_v1_gpu_cluster" "gpu-cluster-slurm" {
   parent_id         = var.parent_id
   name              = "gpu-cluster-slurm"
-  infiniband_fabric = "fabric-5"
+  infiniband_fabric = "fabric-3" # eu-north1
+  # infiniband_fabric = "fabric-5" # eu-west1
 }


### PR DESCRIPTION
## Changes
1. **Updated `infiniband_fabric` configuration in [slurm/gpu_cluster.tf](https://github.com/nebius/nebius-solution-library/compare/main...PhilipMantrov:nebius-solution-library:main?expand=1#diff-b16280cf03d591628adc225365d1d6a52d4396639d4afcb8439d36850cb6a5cd)**  
   - Added eu-west1 variant `infiniband_fabric = "fabric-5"` with comment section.
   **Reason:** `fabric-3` is not available in the `eu-west1` region.

2. **Added hostname to [slurm/files/cloud-config-master.yaml.tftpl](https://github.com/nebius/nebius-solution-library/compare/main...PhilipMantrov:nebius-solution-library:main?expand=1#diff-2698abb5db964a4983004a5f8de0294fafc2fc81bcb25cb47879879caab3bc6c)**  
   - Added `hostname: slurm-master` to the `cloud-config-master.yaml.tftpl` file.  
   **Reason:** Initialization scripts fail during execution if the required hostname is not recognized.

## Testing
- Verified compatibility of the `fabric-5` setting in the `eu-west1` region.
- Tested initialization scripts to ensure they work correctly with the added hostname.

## Checklist
- [x] Code changes tested in the relevant environment.

Let me know if additional changes are required.
