### PR TITLE
Update csi-mounted-fs-path to 0.1.2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Setup s3cmd
       run: |
         pip3 install s3cmd --no-cache --quiet
-        s3cmd --dump-config \
+        s3cmd --configure --dump-config \
         --access_key="${{ secrets.SA_ACCESS_KEY_ID }}" \
         --secret_key="${{ secrets.SA_SECRET_KEY }}" \
         --host="storage.eu-north1.nebius.cloud:443" \

--- a/modules/csi-mounted-fs-path/csi-driver.tf
+++ b/modules/csi-mounted-fs-path/csi-driver.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "csi-mounted-fs-path" {
   name             = "csi-mounted-fs-path"
   chart            = "oci://cr.eu-north1.nebius.cloud/mk8s/helm/csi-mounted-fs-path"
-  version          = "0.1.0"
+  version          = "0.1.2"
   namespace        = "csi-mounted-fs-path"
   create_namespace = true
 }


### PR DESCRIPTION
This version allows to provide tolerations for csi-mounted-fs-path pods.