### PR TITLE
🐛❌ [Bugfix] Use correct SSH CLI flag to specify port

### DIFF
--- a/soperator/test/deliver.sh
+++ b/soperator/test/deliver.sh
@@ -52,7 +52,7 @@ source common/printer.sh
 h1 "Creating directory for tests on ${ADDRESS}..."
 ssh \
   -i "${KEY}" \
-  -P "${PORT}" \
+  -p "${PORT}" \
   "${USER}@${ADDRESS}" \
   mkdir -p "${TEST_DIR}"
 hdone


### PR DESCRIPTION
In the deliver.sh test script, the port is specified with -P which does not work for specifying the port. This commit ensures the correct flag (-p) is used when specifying the port.