### PR TITLE
Soperator: Add a common label to all worker nodegroups and use it in nodeAffinity #232

### DIFF
--- a/soperator/modules/k8s/k8s_ng_accounting.tf
+++ b/soperator/modules/k8s/k8s_ng_accounting.tf
@@ -12,6 +12,7 @@ resource "nebius_mk8s_v1_node_group" "accounting" {
   labels = merge(
     module.labels.label_nodeset_accounting,
     module.labels.label_workload_cpu,
+    module.labels.label_jail,
   )
 
   fixed_node_count = 1
@@ -21,6 +22,7 @@ resource "nebius_mk8s_v1_node_group" "accounting" {
       labels = merge(
         module.labels.label_nodeset_accounting,
         module.labels.label_workload_cpu,
+        module.labels.label_jail,
       )
     }
     taints = [{

--- a/soperator/modules/k8s/k8s_ng_controller.tf
+++ b/soperator/modules/k8s/k8s_ng_controller.tf
@@ -10,6 +10,7 @@ resource "nebius_mk8s_v1_node_group" "controller" {
   labels = merge(
     module.labels.label_nodeset_controller,
     module.labels.label_workload_cpu,
+    module.labels.label_jail,
   )
 
   fixed_node_count = var.node_group_controller.size
@@ -19,6 +20,7 @@ resource "nebius_mk8s_v1_node_group" "controller" {
       labels = merge(
         module.labels.label_nodeset_controller,
         module.labels.label_workload_cpu,
+        module.labels.label_jail,
       )
     }
     taints = [{

--- a/soperator/modules/k8s/k8s_ng_login.tf
+++ b/soperator/modules/k8s/k8s_ng_login.tf
@@ -10,6 +10,7 @@ resource "nebius_mk8s_v1_node_group" "login" {
   labels = merge(
     module.labels.label_nodeset_login,
     module.labels.label_workload_cpu,
+    module.labels.label_jail,
   )
 
   fixed_node_count = var.node_group_login.size
@@ -19,6 +20,7 @@ resource "nebius_mk8s_v1_node_group" "login" {
       labels = merge(
         module.labels.label_nodeset_login,
         module.labels.label_workload_cpu,
+        module.labels.label_jail,
       )
     }
     taints = [{

--- a/soperator/modules/k8s/k8s_ng_system.tf
+++ b/soperator/modules/k8s/k8s_ng_system.tf
@@ -10,6 +10,7 @@ resource "nebius_mk8s_v1_node_group" "system" {
   labels = merge(
     module.labels.label_nodeset_system,
     module.labels.label_workload_cpu,
+    module.labels.label_jail
   )
 
   autoscaling = {
@@ -22,6 +23,7 @@ resource "nebius_mk8s_v1_node_group" "system" {
       labels = merge(
         module.labels.label_nodeset_system,
         module.labels.label_workload_cpu,
+        module.labels.label_jail,
       )
     }
 

--- a/soperator/modules/k8s/k8s_ng_workers.tf
+++ b/soperator/modules/k8s/k8s_ng_workers.tf
@@ -50,6 +50,7 @@ resource "nebius_mk8s_v1_node_group" "worker" {
       ])
     }),
     local.node_group_workload_label.worker[count.index],
+    module.labels.label_jail,
   )
 
   fixed_node_count = var.node_group_workers[count.index].size
@@ -62,6 +63,7 @@ resource "nebius_mk8s_v1_node_group" "worker" {
   template = {
     metadata = {
       labels = merge(
+        module.labels.label_jail,
         tomap({
           (module.labels.key_slurm_nodeset_name) = join("-", [
             module.labels.name_nodeset_worker,

--- a/soperator/modules/labels/main.tf
+++ b/soperator/modules/labels/main.tf
@@ -7,6 +7,7 @@ locals {
     }
 
     name = {
+      jail    = "jail"
       nodeset = "nodeset"
       nodesets = {
         system     = "system"
@@ -30,10 +31,13 @@ locals {
 
     slurm_nodeset  = "${local.const.domain.slurm}/${local.const.name.nodeset}"
     slurm_workload = "${local.const.domain.slurm}/${local.const.name.workload}"
+    jail           = "${local.const.domain.slurm}/${local.const.name.jail}"
   }
 
   label = {
     nebius_gpu = tomap({ (local.label_key.nebius_gpu) = ("true") })
+
+    jail = tomap({ (local.label_key.jail) = ("true") })
 
     nodeset = {
       system     = tomap({ (local.label_key.slurm_nodeset) = (local.const.name.nodesets.system) })

--- a/soperator/modules/labels/outputs.tf
+++ b/soperator/modules/labels/outputs.tf
@@ -92,3 +92,8 @@ output "key_slurm_workload_name" {
   description = "Slurm workload label key."
   value       = local.label_key.slurm_workload
 }
+
+output "label_jail" {
+  description = "System nodeset label."
+  value       = local.label.jail
+}

--- a/soperator/modules/slurm/templates/helm_values/slurm_cluster_storage.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/slurm_cluster_storage.yaml.tftpl
@@ -47,16 +47,10 @@ storage:
 
   jail:
     matchExpressions:
-      - key: ${scheduling.label.nodeset}
+      - key: slurm.nebius.ai/jail
         operator: In
         values:
-          - ${scheduling.system.match}
-          - ${scheduling.controller.match}
-        %{~ for worker in scheduling.worker.matches ~}
-          - ${worker}
-        %{~ endfor ~}
-          - ${scheduling.login.match}
-          - ${scheduling.accounting.match}
+          - "true"
     tolerations:
       - key: ${scheduling.label.nodeset}
         operator: Exists


### PR DESCRIPTION
```
% k get pv jail-submount-shared-pv -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    meta.helm.sh/release-name: slurm-cluster-storage
    meta.helm.sh/release-namespace: soperator
  creationTimestamp: "2025-03-25T09:08:44Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    app.kubernetes.io/managed-by: Helm
  name: jail-submount-shared-pv
  resourceVersion: "5237"
  uid: 00ad67dc-e4b9-4f50-8453-191e60559bf6
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 2Ti
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: jail-submount-shared-pvc
    namespace: soperator
    resourceVersion: "5233"
    uid: 31a318f4-8d2e-43f6-aac3-2ec928094204
  local:
    path: /mnt/jail-submount-shared
  mountOptions:
  - rw
  - relatime
  - exec
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: slurm.nebius.ai/jail
          operator: In
          values:
          - "true"
  persistentVolumeReclaimPolicy: Retain
  storageClassName: slurm-local-pv
  volumeMode: Filesystem
status:
  lastPhaseTransitionTime: "2025-03-25T09:08:44Z"
  phase: Bound


% k get pv jail-pv -oyaml                
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    meta.helm.sh/release-name: slurm-cluster-storage
    meta.helm.sh/release-namespace: soperator
  creationTimestamp: "2025-03-25T09:08:44Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    app.kubernetes.io/managed-by: Helm
  name: jail-pv
  resourceVersion: "5245"
  uid: 315937a8-bfd9-4605-8bc0-ab6734f0c4b7
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 2Ti
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: jail-pvc
    namespace: soperator
    resourceVersion: "5235"
    uid: 597e9d29-c0b7-47cb-94bc-fcc252fbbc36
  local:
    path: /mnt/jail
  mountOptions:
  - rw
  - relatime
  - exec
  - dev
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: slurm.nebius.ai/jail
          operator: In
          values:
          - "true"
  persistentVolumeReclaimPolicy: Retain
  storageClassName: slurm-local-pv
  volumeMode: Filesystem
status:
  lastPhaseTransitionTime: "2025-03-25T09:08:44Z"
  phase: Bound
```