### PR TITLE
Replace quotes in Skypilot task `echo`s

### DIFF
--- a/skypilot/examples/basic-job.yaml
+++ b/skypilot/examples/basic-job.yaml
@@ -4,9 +4,9 @@ resources:
   region: eu-north1
 
 setup: |
-  echo "Setup will be executed on every `sky launch` command on all nodes"
+  echo 'Setup will be executed on every `sky launch` command on all nodes'
 
 run: |
-  echo "Run will be executed on every `sky exec` command on all nodes"
-  echo "Do we have GPUs?"
+  echo 'Run will be executed on every `sky exec` command on all nodes'
+  echo 'Do we have GPUs?'
   nvidia-smi 

--- a/skypilot/examples/test-cloud-bucket.yaml
+++ b/skypilot/examples/test-cloud-bucket.yaml
@@ -8,9 +8,9 @@ file_mounts:
     source: nebius://my-nebius-bucket # must be unique; replace with your own bucket name
 
 setup: |
-  echo "Setup will be executed on every `sky launch` command on all nodes"
+  echo 'Setup will be executed on every `sky launch` command on all nodes'
 
 run: |
-  echo "Run will be executed on every `sky exec` command on all nodes"
-  echo "Do we have data?"
+  echo 'Run will be executed on every `sky exec` command on all nodes'
+  echo 'Do we have data?'
   ls -l /my_data


### PR DESCRIPTION
When the `echo` argument is a double-quote string, everything wrapped in backticks is considered a command and executed. I replace double quotes with single quotes.