### PR TITLE
fix tests race condition by only running one at a time

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,7 +25,7 @@ jobs:
       name: project-e00pjzzrtk1fs3yavy
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         solution:
           - name: k8s-training


### PR DESCRIPTION
In `.github/workflows/terraform.yml` the tests are are run using matrix, which uses the same code, but changes up the variable in the matrix.

With the current setting of `jobs.terraform.strategy.max-parallel: 2`, two jobs can run at the same time, both check out the gh-pages branch at the `Load test report history` step and then one of them pushes updates at the `Publish test report` step.

The 2nd test running in parallel will get an error like below and fail:
```
  /usr/bin/git push origin gh-pages
  To https://github.com/nebius/nebius-solution-library.git
   ! [rejected]          gh-pages -> gh-pages (non-fast-forward)
  error: failed to push some refs to 'https://github.com/nebius/nebius-solution-library.git'
  hint: Updates were rejected because the tip of your current branch is behind
  hint: its remote counterpart. If you want to integrate the remote changes,
  hint: use 'git pull' before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 1"
```

Until the test is refactored to run in parallel, this fix set `max-parallel: 1` so tests run sequentially and don't encounter this race condition and error.