### PR TITLE
fix soperator hello.sh quickcheck

### DIFF
--- a/soperator/test/quickcheck/hello.sh
+++ b/soperator/test/quickcheck/hello.sh
@@ -3,9 +3,8 @@
 #SBATCH -J hello
 #SBATCH --output=results/hello.out
 #SBATCH --error=results/hello.out
-#SBATCH --cpus-per-task=60
-#SBATCH --mem-per-cpu=8G
-#SBATCH --gpus=4
+#SBATCH --ntasks=2
+#SBATCH --gpus=8
 
 # Print hello
 srun \
@@ -14,8 +13,6 @@ srun \
 # Allocate some resources
 srun \
   --ntasks=2 \
-  --cpus-per-task=60 \
-  --mem-per-cpu=8G \
   --gpus=4 \
   echo "Run nvidia-smi on $(hostname)" \
   && nvidia-smi


### PR DESCRIPTION
Test fails because in `sbatch` the default limit of tasks is 1 and srun use using 2.

Also removing allocation of cpu/mem