### PR TITLE
add MIG configuration to 'gpu-operator' and 'k8s-training'

### DIFF
--- a/k8s-training/README.md
+++ b/k8s-training/README.md
@@ -95,7 +95,7 @@ ssh_public_key = {
 ### Kubernetes nodes
 
 ```hcl
-# K8s modes
+# K8s nodes
 cpu_nodes_count  = 3 # Number of CPU nodes
 cpu_nodes_preset = "16vcpu-64gb" # CPU node preset
 gpu_nodes_count  = 1 # Number of GPU nodes
@@ -103,6 +103,16 @@ gpu_nodes_count  = 1 # Number of GPU nodes
 gpu_nodes_preset = "8gpu-128vcpu-1600gb" # The GPU node preset. Only nodes with 8 GPU can be added to gpu cluster with infiniband connection.
 
 ```
+
+### Nvidia Multi Instance GPU (MIG) configuration
+
+```hcl
+# MIG configuration
+mig_strategy = "single" # If set, possible values include 'single', 'mixed', 'none'
+mig_parted_config = "all-disabled" # If set, value will be checked against allowed for the selected 'gpu_nodes_platform'
+```
+
+See [NVIDIA documentation for different MIG strategies](https://docs.nvidia.com/datacenter/cloud-native/kubernetes/latest/index.html#testing-with-different-strategies) and [MIG partitioning configurations for different GPU platforms](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/).
 
 ### Observability options
 

--- a/k8s-training/helm.tf
+++ b/k8s-training/helm.tf
@@ -12,9 +12,9 @@ module "gpu-operator" {
   depends_on = [
     module.network-operator
   ]
-  source     = "../modules/gpu-operator"
-  parent_id  = var.parent_id
-  cluster_id = nebius_mk8s_v1_cluster.k8s-cluster.id
+  source       = "../modules/gpu-operator"
+  parent_id    = var.parent_id
+  cluster_id   = nebius_mk8s_v1_cluster.k8s-cluster.id
   mig_strategy = var.mig_strategy
 }
 

--- a/k8s-training/helm.tf
+++ b/k8s-training/helm.tf
@@ -15,6 +15,7 @@ module "gpu-operator" {
   source     = "../modules/gpu-operator"
   parent_id  = var.parent_id
   cluster_id = nebius_mk8s_v1_cluster.k8s-cluster.id
+  mig_strategy = var.mig_strategy
 }
 
 module "o11y" {

--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -27,6 +27,11 @@ locals {
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
   infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
+
+  valid_mig_parted_configs = {
+    "gpu-h100-sxm" = ["all-disabled", "all-enabled", "all-balanced", "all-1g.10gb", "all-1g.10gb.me", "all-1g.20gb", "all-2g.20gb", "all-3g.40gb", "all-4g.40gb", "all-7g.80gb"]
+    "gpu-h200-sxm" = ["all-disabled", "all-enabled", "all-balanced", "all-1g.18gb", "all-1g.18gb.me", "all-1g.35gb", "all-2g.35gb", "all-3g.71gb", "all-4g.71gb", "all-7g.141gb"]
+  }
 }
 
 resource "random_string" "random" {

--- a/k8s-training/main.tf
+++ b/k8s-training/main.tf
@@ -83,6 +83,12 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
   }
   version = var.k8s_version
   template = {
+    metadata = {
+      labels = var.mig_parted_config != null ? {
+        "nvidia.com/mig.config" = var.mig_parted_config
+      } : {}
+    }
+
     boot_disk = {
       size_gibibytes = var.gpu_disk_size
       type           = var.gpu_disk_type

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -15,6 +15,10 @@ gpu_nodes_count = 1 # Number of GPU nodes
 # infiniband_fabric  =                 # Infiniband fabric name.
 enable_k8s_node_group_sa = true
 
+# MIG configuration
+# mig_strategy =        # If set, possible values include 'single', 'mixed', 'none'
+# mig_parted_config =   # If set, value will be checked against allowed for the selected 'gpu_nodes_platform'
+
 # Observability
 enable_grafana    = true  # Enable or disable Grafana deployment with true or false
 enable_prometheus = true  # Enable or disable Prometheus deployment with true or false

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -195,6 +195,17 @@ variable "enable_k8s_node_group_sa" {
   default     = true
 }
 
+variable "mig_parted_config" {
+  description = "MIG partition config to be assigned to node group label"
+  type = string
+  default = null
+
+  validation {
+    condition     = var.mig_parted_config == null || contains(local.valid_mig_parted_configs[local.gpu_nodes_platform], coalesce(var.mig_parted_config, "null"))
+    error_message = "Invalid MIG config '${coalesce(var.mig_parted_config, "null")}' for the selected GPU platform '${local.gpu_nodes_platform}'. Must be one of ${join(", ", local.valid_mig_parted_configs[local.gpu_nodes_platform])} or left unset."
+  }
+}
+
 # Observability
 variable "enable_grafana" {
   description = "Enable Grafana."
@@ -258,4 +269,10 @@ variable "kuberay_max_gpu_replicas" {
   description = "Minimum amount of kuberay gpu worker pods"
   type        = number
   default     = 1
+}
+
+variable "mig_strategy" {
+  description = "MIG strategy for GPU operator"
+  type        = string
+  default     = null
 }

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -197,8 +197,8 @@ variable "enable_k8s_node_group_sa" {
 
 variable "mig_parted_config" {
   description = "MIG partition config to be assigned to node group label"
-  type = string
-  default = null
+  type        = string
+  default     = null
 
   validation {
     condition     = var.mig_parted_config == null || contains(local.valid_mig_parted_configs[local.gpu_nodes_platform], coalesce(var.mig_parted_config, "null"))

--- a/modules/gpu-operator/main.tf
+++ b/modules/gpu-operator/main.tf
@@ -15,5 +15,6 @@ resource "nebius_applications_v1alpha1_k8s_release" "this" {
     "dcgmExporter.serviceMonitor.relabelings[0].replacement" : var.relabel_dcgm_exporter ? "dcgm-exporter" : null,
     "dcgmExporter.serviceMonitor.relabelings[0].sourceLabels[0]" : var.relabel_dcgm_exporter ? "__meta_kubernetes_pod_label_app" : null,
     "dcgmExporter.serviceMonitor.relabelings[0].targetLabel" : var.relabel_dcgm_exporter ? "app_kubernetes_io_name" : null,
+    "mig.strategy" : var.mig_strategy != null ? var.mig_strategy : null,
   }
 }

--- a/modules/gpu-operator/variables.tf
+++ b/modules/gpu-operator/variables.tf
@@ -25,3 +25,14 @@ variable "relabel_dcgm_exporter" {
   type        = bool
   default     = false
 }
+
+variable "mig_strategy" {
+  description = "MIG strategy for GPU nodes."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.mig_strategy == null || contains(["none", "single", "mixed"], coalesce(var.mig_strategy, "null"))
+    error_message = "Invalid MIG strategy '${coalesce(var.mig_strategy, "null")}'. Must be one of ['none', 'single', 'mixed'] or left unset."
+  }
+}


### PR DESCRIPTION
This PR adds 2 things:
- Setting `mig.strategy` for `gpu-operator` module
- Setting node label with MIG partitioning configuration for `k8s-training`

To use with `k8s-training`, edit the `terraform.tfvars` file:

```hcl
mig_strategy = "mixed"       # If set, possible values include 'single', 'mixed', 'none'
mig_parted_config = "all-1g.20gb" # If set, value will be checked against allowed for the selected 'gpu_nodes_platform'
```

This configuration will apply `mixed` MIG strategy to the `gpu-operator` (meaning the resulting MIG slices will appear as `nvidia.com/mig-<slice-type>` resource) and the slicing of type `all-1g.20gb` (only applicable to H100 GPU, possible values are validated with GPU platform, see [this link for MIG profile](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#h100-mig-profiles)).