### PR TITLE
Don't call scontrol from within prolog/epilog scripts to drain the node

### DIFF
--- a/soperator/modules/slurm/templates/slurm_epilog_cm.yaml.tftpl
+++ b/soperator/modules/slurm/templates/slurm_epilog_cm.yaml.tftpl
@@ -4,26 +4,36 @@ resources:
     metadata:
       name: slurm-epilog
     data:
+      # language=bash
       epilog.sh: |-
         #!/bin/bash
 
-        if [ -n "$SLURM_JOB_GPUS" ]; then
-          cd /tmp
-
-          echo "Execute nvidia-smi health check"
-          rm /tmp/nvidia-smi.out 2> /dev/null
-          nvidia-smi 1> /tmp/nvidia-smi.out
-          if [ $? -gt 0 ]; then
-            scontrol update nodename=$SLURMD_NODENAME state=drain reason="Failed nvidia-smi, see /tmp/nvidia-smi.out"
-            exit 0
-          fi
-
-          echo "Execute dcgm health check"
-          rm /tmp/dcgm.out 2> /dev/null
-          chroot /mnt/jail dcgmi diag -r 1 1> /tmp/dcgm.out
-          grep -i Fail /tmp/dcgm.out > /dev/null
-          if [ $? -eq 0 ]; then
-            scontrol update nodename=$SLURMD_NODENAME state=drain reason="Failed DCGM, see /tmp/dcgm.out"
-            exit 0
-          fi
+        if [ -z "$SLURM_JOB_GPUS" ]; then
+          echo 'Skipping GPU health check as there are no GPUs requested for this job'
+          exit
         fi
+
+        cd /tmp
+
+        echo 'Executing nvidia-smi health check'
+        rm /tmp/nvidia-smi-epilog.out 2> /dev/null
+        nvidia-smi 1> /tmp/nvidia-smi-epilog.out
+        rc=$?
+        if [ ${rc} -ne 0 ]; then
+          echo "Failed nvidia-smi with return code ${rc}, see /tmp/nvidia-smi-epilog.out"
+          echo 'Node will be drained by Slurm'
+          exit ${rc}
+        fi
+        echo 'nvidia-smi health check passed'
+
+        echo 'Executing dcgm health check'
+        rm /tmp/dcgm-epilog.out 2> /dev/null
+        chroot /mnt/jail dcgmi diag -r 1 1> /tmp/dcgm-epilog.out
+        grep -i Fail /tmp/dcgm-epilog.out > /dev/null
+        rc=$?
+        if [ ${rc} -eq 0 ]; then
+          echo 'Failed DCGM, see /tmp/dcgm-epilog.out'
+          echo 'Node will be drained by Slurm'
+          exit 1
+        fi
+        echo 'dcgm health check passed'

--- a/soperator/modules/slurm/templates/slurm_prolog_cm.yaml.tftpl
+++ b/soperator/modules/slurm/templates/slurm_prolog_cm.yaml.tftpl
@@ -4,17 +4,24 @@ resources:
     metadata:
       name: slurm-prolog
     data:
+      # language=bash
       prolog.sh: |-
         #!/bin/bash
 
-        if [ -n "$SLURM_JOB_GPUS" ]; then
-          cd /tmp
-
-          echo "Execute nvidia-smi health check"
-          rm /tmp/nvidia-smi.out 2> /dev/null
-          nvidia-smi 1> /tmp/nvidia-smi.out
-          if [ $? -gt 0 ]; then
-            scontrol update nodename=$SLURMD_NODENAME state=drain reason="Failed nvidia-smi, see /tmp/nvidia-smi.out"
-            exit 0
-          fi
+        if [ -z "$SLURM_JOB_GPUS" ]; then
+          echo 'Skipping GPU health check as there are no GPUs requested for this job'
+          exit
         fi
+
+        cd /tmp
+
+        echo 'Executing nvidia-smi health check'
+        rm /tmp/nvidia-smi-prolog.out 2> /dev/null
+        nvidia-smi 1> /tmp/nvidia-smi-prolog.out
+        rc=$?
+        if [ ${rc} -ne 0 ]; then
+          echo "Failed nvidia-smi with return code ${rc}, see /tmp/nvidia-smi-prolog.out"
+          echo 'Node will be drained by Slurm'
+          exit ${rc}
+        fi
+        echo 'nvidia-smi health check passed'


### PR DESCRIPTION
There are few sections in [Slurm doc](https://slurm.schedmd.com/prolog_epilog.html):

> Prolog and Epilog scripts should be designed to be as short as possible and should not call Slurm commands (e.g. squeue, scontrol, sacctmgr, etc). Long running scripts can cause scheduling problems when jobs take a long time to start or finish. Slurm commands in these scripts can potentially lead to performance issues and should not be used.

And we had such issues with Prolog scripts being hung on un-performant nodes:
```
slurmstepd: error: Prolog hung on node worker-X
```

> If the Epilog fails (returns a non-zero exit code), this will result in the node being set to a DRAIN state. If the EpilogSlurmctld fails (returns a non-zero exit code), this will only be logged. If the Prolog fails (returns a non-zero exit code), this will result in the node being set to a DRAIN state and the job requeued.

So, exiting with non-zero code should work the same as with draining the node with `scontrol update`, but should not cause performance issues and hanging scripts.