### PR TITLE
Disabling unnecessary default enabled public IPs

### DIFF
--- a/modules/gluster-module/instances.tf
+++ b/modules/gluster-module/instances.tf
@@ -10,7 +10,7 @@ resource "nebius_compute_v1_instance" "gluster-fs-instance" {
       ip_address : {
         allocation_id = nebius_vpc_v1alpha1_allocation.glusterfs[count.index].id
       }
-      public_ip_address : count.index == 0 ? {} : null
+      public_ip_address : (var.public_ip && count.index == 0) ? {} : null
     }
   ]
   resources = {

--- a/modules/gluster-module/variables.tf
+++ b/modules/gluster-module/variables.tf
@@ -58,3 +58,10 @@ variable "ssh_public_key" {
   description = "SSH public key for the 'root' user."
   type        = string
 }
+
+# PUBLIC IP
+variable "public_ip" {
+  type        = bool
+  default     = false
+  description = "attach a public ip to the vm if true"
+}

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -98,12 +98,12 @@ variable "extra_storage_class" {
   description = "Network type of additional disk being added"
 }
 
-
 variable "public_ip" {
   type        = bool
-  default     = true
+  default     = false
   description = "attach a public ip to the vm if true"
 }
+
 variable "mount_bucket" {
   type        = string
   description = "name of a bucket that should be mounted into fs"

--- a/modules/nfs-server/main.tf
+++ b/modules/nfs-server/main.tf
@@ -7,7 +7,7 @@ resource "nebius_compute_v1_instance" "nfs_server" {
       name              = "eth0"
       subnet_id         = var.subnet_id
       ip_address        = {}
-      public_ip_address = {}
+      public_ip_address = var.public_ip ? {} : null
     }
   ]
 

--- a/modules/nfs-server/variables.tf
+++ b/modules/nfs-server/variables.tf
@@ -85,3 +85,10 @@ variable "nfs_disk_name_suffix" {
   description = "Name suffix to be able to create several NFS disks in the same parent"
   default     = ""
 }
+
+# PUBLIC IP
+variable "public_ip" {
+  type        = bool
+  default     = false
+  description = "attach a public ip to the vm if true"
+}

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -19,7 +19,7 @@ users = [
   }
 ]
 
-public_ip = true
+public_ip = false
 instance_count = 1
 
 shared_filesystem_id = ""


### PR DESCRIPTION
- Defaulted public IP in vm-instance example and instance module to false.
- Amended condition for gluster fs module conditionally disabling public_ip completely
- Added public IP condiition for NFS module.