### PR TITLE
Changed public IP behavior

### DIFF
--- a/modules/gluster-module/instances.tf
+++ b/modules/gluster-module/instances.tf
@@ -10,7 +10,7 @@ resource "nebius_compute_v1_instance" "gluster-fs-instance" {
       ip_address : {
         allocation_id = nebius_vpc_v1alpha1_allocation.glusterfs[count.index].id
       }
-      public_ip_address : count.index == 0 ? {} : null
+      public_ip_address : (var.public_ip && count.index == 0) ? {} : null
     }
   ]
   resources = {

--- a/modules/gluster-module/variables.tf
+++ b/modules/gluster-module/variables.tf
@@ -58,3 +58,10 @@ variable "ssh_public_key" {
   description = "SSH public key for the 'root' user."
   type        = string
 }
+
+# PUBLIC IP
+variable "public_ip" {
+  type        = bool
+  default     = false
+  description = "attach a public ip to the vm if true"
+}

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -26,7 +26,7 @@ resource "nebius_compute_v1_instance" "instance" {
       name              = "eth0"
       subnet_id         = var.subnet_id
       ip_address        = {}
-      public_ip_address = var.public_ip ? {} : null
+      public_ip_address = var.public_ip ? (var.create_public_ip_for_all_instances || count.index == 0 ? {} : null) : null
     }
   ]
 

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -98,12 +98,12 @@ variable "extra_storage_class" {
   description = "Network type of additional disk being added"
 }
 
-
 variable "public_ip" {
   type        = bool
-  default     = true
+  default     = false
   description = "attach a public ip to the vm if true"
 }
+
 variable "mount_bucket" {
   type        = string
   description = "name of a bucket that should be mounted into fs"

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -100,8 +100,14 @@ variable "extra_storage_class" {
 
 variable "public_ip" {
   type        = bool
+  default     = true
+  description = "attach a public ip to the first created vm if true"
+}
+
+variable "create_public_ip_for_all_instances" {
+  type        = bool
   default     = false
-  description = "attach a public ip to the vm if true"
+  description = "attach a public ip to all vms if true"
 }
 
 variable "mount_bucket" {

--- a/modules/nfs-server/main.tf
+++ b/modules/nfs-server/main.tf
@@ -7,7 +7,7 @@ resource "nebius_compute_v1_instance" "nfs_server" {
       name              = "eth0"
       subnet_id         = var.subnet_id
       ip_address        = {}
-      public_ip_address = {}
+      public_ip_address = var.public_ip ? {} : null
     }
   ]
 

--- a/modules/nfs-server/variables.tf
+++ b/modules/nfs-server/variables.tf
@@ -85,3 +85,10 @@ variable "nfs_disk_name_suffix" {
   description = "Name suffix to be able to create several NFS disks in the same parent"
   default     = ""
 }
+
+# PUBLIC IP
+variable "public_ip" {
+  type        = bool
+  default     = false
+  description = "attach a public ip to the vm if true"
+}

--- a/vm-instance/README.md
+++ b/vm-instance/README.md
@@ -36,6 +36,11 @@ terraform apply
 
 ### Example 1: Basic Configuration with One User
 
+The module is configured to enable public IP only for the first instance created by it.
+*Overrider this behaviour by setting `create_public_ip_for_all_instances`to `true` in `terraform.tfvars`
+*Consider setting the value of public_ip to False if you do not require public IP addresses. 
+*Consider using [Bastion](https://github.com/nebius/nebius-solution-library/tree/main/bastion) solution if you need to manage a set of virtual machines in the same network.
+
 ```
 preset = "16vcpu-64gb"
 platform = "cpu-e2"

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -19,7 +19,7 @@ users = [
   }
 ]
 
-public_ip = true
+public_ip = false
 instance_count = 1
 
 shared_filesystem_id = ""

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -19,7 +19,8 @@ users = [
   }
 ]
 
-public_ip = false
+public_ip = true
+create_public_ip_for_all_instances = false
 instance_count = 1
 
 shared_filesystem_id = ""

--- a/vm-instance/variables.tf
+++ b/vm-instance/variables.tf
@@ -96,6 +96,12 @@ variable "public_ip" {
   description = "attach a public ip to the vm if true"
 }
 
+variable "create_public_ip_for_all_instances" {
+  type        = bool
+  default     = false
+  description = "attach a public ip to all vms if true"
+}
+
 variable "mount_bucket" {
   type        = string
   description = "name of a bucket that should be mounted into fs"


### PR DESCRIPTION
nfs-server
- Old behavior: create public IP for instance
- New behavior: create public IP for instance if public_ip = true
- public_ip = false by default

gluster
- Old behavior: create public IP for instance if it's the first instance created via this module.
- New behavior: create public IP for instance if it's the first instance created via this module and if public_ip = true
- public_ip = false by default

instance
- Old behavior: create public IP for instance
- New behavior: create public IP for instance if it's the first instance created via this module and if public_ip = true OR if create_public_ip_for_all_instances = true.
- public_ip = true by default
- create_public_ip_for_all_instances = false by default