### PR TITLE
Grafana dashboard fixes

### DIFF
--- a/soperator/modules/monitoring/templates/dashboards/jobs_overview.yaml.tftpl
+++ b/soperator/modules/monitoring/templates/dashboards/jobs_overview.yaml.tftpl
@@ -95,7 +95,7 @@ resources:
                   "showLineNumbers": false,
                   "showMiniMap": false
                 },
-                "content": "* You can select multiple Jobs, list of Workers will be filtered based on that, only one of the jobs is selected by default\n* You can select multiple Workers, All are selected by default\n* Stats in all panels will be based on selected Jobs and Workers\n",
+                "content": "* You can select multiple Jobs, list of Workers will be filtered based on that, only one of the jobs is selected by default\n* You can select multiple Workers, All are selected by default\n* Stats in all panels will be based on selected Jobs and Workers\n* check per worker stats below when there are large variance in cluster level stats, or when you want to spot outlier workers\n",
                 "mode": "markdown"
               },
               "pluginVersion": "11.4.0",
@@ -788,7 +788,7 @@ resources:
                   "showLineNumbers": false,
                   "showMiniMap": false
                 },
-                "content": "* Timeline shows range of time that metrics were collected for a job\n* Colors reflect number of workers assigned to that job, the spectrum is visualized as legend of the graph\n\nSelected Jobs: `$slurm_job`",
+                "content": "* Timeline shows range of time that metrics were collected for a job\n* Colors reflect number of workers assigned to that job, the spectrum is visualized as legend of the graph\n",
                 "mode": "markdown"
               },
               "pluginVersion": "11.4.0",
@@ -1963,6 +1963,648 @@ resources:
               ],
               "title": "Infiniband Throughput",
               "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 30
+              },
+              "id": 369,
+              "panels": [],
+              "title": "GPU Stats per Worker",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "purple",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 3,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "fieldMinMax": false,
+                  "mappings": [],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 31
+              },
+              "id": 370,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "GPU Avg Utilization per Worker",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 1,
+                    "pointSize": 3,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "links": [],
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 31
+              },
+              "id": 371,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "avg by (exported_pod) (DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "GPU Avg Mem Usage per Worker",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "light-yellow",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 31
+              },
+              "id": 372,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "avg by (exported_pod) (DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "GPU Avg Mem Copy Utilization per Worker",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "light-green",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 39
+              },
+              "id": 373,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (exported_pod) (DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "GPU Total Power Usage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "light-red",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 39
+              },
+              "id": 374,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "GPU Avg Temperature per Worker",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "light-red",
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 1,
+                    "pointSize": 0,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/No Error.*/"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 39
+              },
+              "id": 375,
+              "interval": "2m",
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.4.0",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "VictoriaMetrics"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (err_msg, exported_pod) (rate(DCGM_FI_DEV_XID_ERRORS{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
+                  "instant": false,
+                  "legendFormat": "{{exported_pod}}: {{err_msg}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "XID errors",
+              "type": "timeseries"
             }
           ],
           "preload": false,
@@ -2110,6 +2752,6 @@ resources:
           },
           "timezone": "browser",
           "title": "Jobs Overview",
-          "version": 27,
+          "version": 28,
           "weekStart": ""
         }

--- a/soperator/modules/monitoring/templates/dashboards/workers_detailed_stats.yaml.tftpl
+++ b/soperator/modules/monitoring/templates/dashboards/workers_detailed_stats.yaml.tftpl
@@ -162,9 +162,7 @@ resources:
                 "orientation": "horizontal",
                 "percentChangeColorMode": "standard",
                 "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "fields": "",
                   "values": false
                 },
@@ -241,9 +239,7 @@ resources:
                 "orientation": "horizontal",
                 "percentChangeColorMode": "standard",
                 "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "fields": "",
                   "values": false
                 },
@@ -354,9 +350,7 @@ resources:
               "id": 332,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -458,9 +452,7 @@ resources:
               "id": 57,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -561,9 +553,7 @@ resources:
               "id": 326,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -665,9 +655,7 @@ resources:
               "id": 39,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -767,9 +755,7 @@ resources:
               "id": 325,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -869,9 +855,7 @@ resources:
               "id": 25,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -984,9 +968,7 @@ resources:
               "id": 327,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -1112,9 +1094,7 @@ resources:
               "id": 330,
               "options": {
                 "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                  "calcs": ["lastNotNull"],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -1362,12 +1342,7 @@ resources:
                   "id": 3,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -1872,12 +1847,7 @@ resources:
                   "id": 24,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -2156,12 +2126,7 @@ resources:
                   "id": 84,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2274,12 +2239,7 @@ resources:
                   "id": 156,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2709,12 +2669,7 @@ resources:
                   "id": 229,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2939,12 +2894,7 @@ resources:
                   "id": 42,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -3087,12 +3037,7 @@ resources:
                   "id": 127,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -3224,12 +3169,7 @@ resources:
                   "id": 319,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -3611,12 +3551,7 @@ resources:
                   "id": 136,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -4004,12 +3939,7 @@ resources:
                   "id": 135,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -4378,12 +4308,7 @@ resources:
                   "id": 191,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -4810,12 +4735,7 @@ resources:
                   "id": 130,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -5219,12 +5139,7 @@ resources:
                   "id": 138,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -5619,12 +5534,7 @@ resources:
                   "id": 160,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -6009,12 +5919,7 @@ resources:
                   "id": 70,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -6424,12 +6329,7 @@ resources:
                   "id": 129,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -6827,12 +6727,7 @@ resources:
                   "id": 132,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -7218,12 +7113,7 @@ resources:
                   "id": 307,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -7336,12 +7226,7 @@ resources:
                   "id": 176,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -7728,12 +7613,7 @@ resources:
                   "id": 175,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -8185,12 +8065,7 @@ resources:
                   "id": 9,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -8613,12 +8488,7 @@ resources:
                   "id": 33,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -9043,12 +8913,7 @@ resources:
                   "id": 37,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -9464,12 +9329,7 @@ resources:
                   "id": 35,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -9882,12 +9742,7 @@ resources:
                   "id": 133,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -10299,12 +10154,7 @@ resources:
                   "id": 36,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -10718,12 +10568,7 @@ resources:
                   "id": 34,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11124,12 +10969,7 @@ resources:
                   "id": 301,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11256,12 +11096,7 @@ resources:
                   "id": 43,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11390,12 +11225,7 @@ resources:
                   "id": 41,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11497,12 +11327,7 @@ resources:
                   "id": 28,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11615,12 +11440,7 @@ resources:
                   "id": 219,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11739,12 +11559,7 @@ resources:
                   "id": 44,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11943,12 +11758,7 @@ resources:
                   "id": 60,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -12075,12 +11885,7 @@ resources:
                   "id": 142,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -12205,12 +12010,7 @@ resources:
                   "id": 143,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -12343,12 +12143,7 @@ resources:
                   "id": 61,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12461,12 +12256,7 @@ resources:
                   "id": 280,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12565,12 +12355,7 @@ resources:
                   "id": 309,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -12721,12 +12506,7 @@ resources:
                   "id": 55,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12839,12 +12619,7 @@ resources:
                   "id": 109,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13018,12 +12793,7 @@ resources:
                   "id": 299,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13139,12 +12909,7 @@ resources:
                   "id": 104,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13349,12 +13114,7 @@ resources:
                   "id": 85,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13470,12 +13230,7 @@ resources:
                   "id": 82,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13603,12 +13358,7 @@ resources:
                   "id": 8,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13721,12 +13471,7 @@ resources:
                   "id": 7,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13850,12 +13595,7 @@ resources:
                   "id": 151,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14017,12 +13757,7 @@ resources:
                   "id": 322,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14204,12 +13939,7 @@ resources:
                   "id": 64,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14320,12 +14050,7 @@ resources:
                   "id": 306,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14425,12 +14150,7 @@ resources:
                   "id": 308,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14561,12 +14281,7 @@ resources:
                   "id": 260,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14696,12 +14411,7 @@ resources:
                   "id": 291,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14818,12 +14528,7 @@ resources:
                   "id": 168,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14937,12 +14642,7 @@ resources:
                   "id": 294,
                   "options": {
                     "legend": {
-                      "calcs": [
-                        "mean",
-                        "lastNotNull",
-                        "max",
-                        "min"
-                      ],
+                      "calcs": ["mean", "lastNotNull", "max", "min"],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true

--- a/soperator/modules/monitoring/templates/dashboards/workers_detailed_stats.yaml.tftpl
+++ b/soperator/modules/monitoring/templates/dashboards/workers_detailed_stats.yaml.tftpl
@@ -34,11 +34,9 @@ resources:
           },
           "editable": true,
           "fiscalYearStartMonth": 0,
-          "gnetId": 1860,
           "graphTooltip": 1,
-          "id": 12,
+          "id": 107,
           "links": [],
-          "liveNow": false,
           "panels": [
             {
               "datasource": {
@@ -96,7 +94,7 @@ resources:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "11.1.0",
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
@@ -164,7 +162,9 @@ resources:
                 "orientation": "horizontal",
                 "percentChangeColorMode": "standard",
                 "reduceOptions": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "fields": "",
                   "values": false
                 },
@@ -172,7 +172,7 @@ resources:
                 "textMode": "auto",
                 "wideLayout": true
               },
-              "pluginVersion": "11.1.0",
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
@@ -241,7 +241,9 @@ resources:
                 "orientation": "horizontal",
                 "percentChangeColorMode": "standard",
                 "reduceOptions": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "fields": "",
                   "values": false
                 },
@@ -249,7 +251,7 @@ resources:
                 "textMode": "auto",
                 "wideLayout": true
               },
-              "pluginVersion": "11.1.0",
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
@@ -270,10 +272,6 @@ resources:
             },
             {
               "collapsed": false,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "VictoriaMetrics"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -282,15 +280,6 @@ resources:
               },
               "id": 19,
               "panels": [],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "VictoriaMetrics"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "GPU",
               "type": "row"
             },
@@ -311,6 +300,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -364,7 +354,9 @@ resources:
               "id": 332,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -374,13 +366,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum without (hpc_job) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\"}/(DCGM_FI_DEV_FB_USED{Hostname=~\"$node\"}+DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\"}))",
+                  "expr": "sum by (gpu) (\n  DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", exported_pod=~\"$worker\"})\n)",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -410,6 +403,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -464,7 +458,9 @@ resources:
               "id": 57,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -474,13 +470,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum without(hpc_job) (DCGM_FI_DEV_GPU_UTIL{Hostname=~\"$node\"})",
+                  "expr": "sum by(gpu) (DCGM_FI_DEV_GPU_UTIL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -510,6 +507,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -563,7 +561,9 @@ resources:
               "id": 326,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -573,13 +573,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "1e6*sum(DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{Hostname=~\"$node\"})",
+                  "expr": "1e6*sum(DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -609,6 +610,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -663,7 +665,9 @@ resources:
               "id": 39,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -673,13 +677,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum without(hpc_job) (DCGM_FI_DEV_MEM_COPY_UTIL{Hostname=~\"$node\"})",
+                  "expr": "sum by(gpu) (DCGM_FI_DEV_MEM_COPY_UTIL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -709,6 +714,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -761,7 +767,9 @@ resources:
               "id": 325,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -771,13 +779,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum without(hpc_job) (DCGM_FI_DEV_POWER_USAGE{Hostname=~\"$node\"})",
+                  "expr": "sum by(gpu) (DCGM_FI_DEV_POWER_USAGE{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -807,6 +816,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -859,7 +869,9 @@ resources:
               "id": 25,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": false
@@ -869,13 +881,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum without(hpc_job) (DCGM_FI_DEV_GPU_TEMP{Hostname=~\"$node\"})",
+                  "expr": "sum by(gpu) (DCGM_FI_DEV_GPU_TEMP{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -905,6 +918,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -970,7 +984,9 @@ resources:
               "id": 327,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -980,13 +996,14 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
                   "editorMode": "code",
-                  "expr": "sum(DCGM_FI_PROF_PCIE_TX_BYTES{Hostname=~\"$node\"})",
+                  "expr": "sum(DCGM_FI_PROF_PCIE_TX_BYTES{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
@@ -999,12 +1016,14 @@ resources:
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
-                  "expr": "sum(DCGM_FI_PROF_PCIE_RX_BYTES{instance=~\"$ip\"})",
+                  "editorMode": "code",
+                  "expr": "sum(DCGM_FI_PROF_PCIE_RX_BYTES{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 2,
                   "legendFormat": "Rx",
+                  "range": true,
                   "refId": "B"
                 }
               ],
@@ -1027,6 +1046,7 @@ resources:
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
+                    "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 20,
                     "gradientMode": "opacity",
@@ -1092,7 +1112,9 @@ resources:
               "id": 330,
               "options": {
                 "legend": {
-                  "calcs": ["lastNotNull"],
+                  "calcs": [
+                    "lastNotNull"
+                  ],
                   "displayMode": "list",
                   "placement": "bottom",
                   "showLegend": true
@@ -1102,24 +1124,28 @@ resources:
                   "sort": "none"
                 }
               },
+              "pluginVersion": "11.4.0",
               "targets": [
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
-                  "expr": "sum(rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval]))",
+                  "editorMode": "code",
+                  "expr": "sum(\n  rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n)\n",
                   "format": "time_series",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 2,
                   "legendFormat": "Transmit",
+                  "range": true,
                   "refId": "B"
                 },
                 {
                   "datasource": {
                     "uid": "VictoriaMetrics"
                   },
-                  "expr": "sum(rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval]))",
+                  "editorMode": "code",
+                  "expr": "sum(\n  rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
                   "format": "time_series",
                   "hide": false,
                   "instant": false,
@@ -1134,10 +1160,6 @@ resources:
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1164,6 +1186,7 @@ resources:
                         "axisLabel": "percentage",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -1334,12 +1357,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 0,
-                    "y": 6
+                    "y": 27
                   },
                   "id": 3,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -1350,7 +1378,7 @@ resources:
                       "sort": "desc"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
@@ -1358,7 +1386,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"system\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"system\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -1373,7 +1401,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"user\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"user\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "User - Normal processes executing in user mode",
@@ -1387,7 +1415,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"nice\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"nice\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Nice - Niced processes executing in user mode",
@@ -1401,7 +1429,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum by(instance) (irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"iowait\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"iowait\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Iowait - Waiting for I/O to complete",
@@ -1415,7 +1443,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"irq\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"irq\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Irq - Servicing interrupts",
@@ -1429,7 +1457,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"softirq\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"softirq\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Softirq - Servicing softirqs",
@@ -1443,7 +1471,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"steal\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"steal\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Steal - Time spent in other operating systems when running in a virtualized environment",
@@ -1457,7 +1485,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "sum(irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"idle\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
+                      "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"idle\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1488,6 +1516,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -1838,12 +1867,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 12,
-                    "y": 6
+                    "y": 27
                   },
                   "id": 24,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -1854,18 +1888,20 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_MemTotal_bytes{instance=~\"$ip\"} - node_memory_MemFree_bytes{instance=~\"$ip\"} - node_memory_Buffers_bytes{instance=~\"$ip\"} - node_memory_Cached_bytes{instance=~\"$ip\"} - node_memory_Slab_bytes{instance=~\"$ip\"} - node_memory_PageTables_bytes{instance=~\"$ip\"} - node_memory_SwapCached_bytes{instance=~\"$ip\"}",
+                      "editorMode": "code",
+                      "expr": "(node_memory_MemTotal_bytes{instance=~\"$ip\"} - node_memory_MemFree_bytes{instance=~\"$ip\"} - node_memory_Buffers_bytes{instance=~\"$ip\"} - node_memory_Cached_bytes{instance=~\"$ip\"} - node_memory_Slab_bytes{instance=~\"$ip\"} - node_memory_PageTables_bytes{instance=~\"$ip\"} - node_memory_SwapCached_bytes{instance=~\"$ip\"})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
                       "legendFormat": "Apps - Memory used by user-space applications",
+                      "range": true,
                       "refId": "A",
                       "step": 240
                     },
@@ -1874,7 +1910,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_PageTables_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_PageTables_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1887,7 +1923,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_SwapCached_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_SwapCached_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "SwapCache - Memory that keeps track of pages that have been fetched from swap but not yet been modified",
@@ -1899,7 +1935,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Slab_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Slab_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1912,7 +1948,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Cached_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Cached_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1925,7 +1961,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Buffers_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Buffers_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1938,7 +1974,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_MemFree_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_MemFree_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1951,7 +1987,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "(node_memory_SwapTotal_bytes{instance=~\"$ip\"} - node_memory_SwapFree_bytes{instance=~\"$ip\"})",
+                      "expr": "(node_memory_SwapTotal_bytes{instance=~\"$ip\"} - node_memory_SwapFree_bytes{instance=~\"$ip\"})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1964,7 +2000,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_HardwareCorrupted_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_HardwareCorrupted_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -1993,6 +2029,7 @@ resources:
                         "axisLabel": "bits out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -2114,12 +2151,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 0,
-                    "y": 18
+                    "y": 39
                   },
                   "id": 84,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2129,14 +2171,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_receive_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8",
+                      "expr": "irate(node_network_receive_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Receive",
@@ -2148,7 +2190,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_transmit_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8",
+                      "expr": "irate(node_network_transmit_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Transmit",
@@ -2177,6 +2219,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -2226,12 +2269,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 12,
-                    "y": 18
+                    "y": 39
                   },
                   "id": 156,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2241,17 +2289,19 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'} - node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'}",
+                      "editorMode": "code",
+                      "expr": "(node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'} - node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{mountpoint}}",
+                      "range": true,
                       "refId": "A",
                       "step": 240
                     }
@@ -2277,6 +2327,7 @@ resources:
                         "axisLabel": "IO read (-) / write (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -2308,7 +2359,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -2652,12 +2704,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 0,
-                    "y": 30
+                    "y": 51
                   },
                   "id": 229,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2667,14 +2724,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - Reads completed",
                       "refId": "A",
@@ -2685,7 +2742,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Writes completed",
                       "refId": "B",
@@ -2713,6 +2770,7 @@ resources:
                         "axisLabel": "bytes read (-) / write (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -2744,7 +2802,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -2875,12 +2934,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 12,
-                    "y": 30
+                    "y": 51
                   },
                   "id": 42,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -2890,14 +2954,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -2910,7 +2974,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -2940,6 +3004,7 @@ resources:
                         "axisLabel": "%util",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -2972,7 +3037,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -3016,12 +3082,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 0,
-                    "y": 42
+                    "y": 63
                   },
                   "id": 127,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -3031,14 +3102,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\",device=~\"$diskdevices\"} [$__rate_interval])",
+                      "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\",device=~\"$diskdevices\"} [$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -3068,6 +3139,7 @@ resources:
                         "axisLabel": "percentage",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "bars",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -3099,7 +3171,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -3146,12 +3219,17 @@ resources:
                     "h": 12,
                     "w": 12,
                     "x": 12,
-                    "y": 42
+                    "y": 63
                   },
                   "id": 319,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -3161,6 +3239,7 @@ resources:
                       "sort": "desc"
                     }
                   },
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
@@ -3191,24 +3270,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "CPU / Memory / Net / Disk",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -3234,6 +3300,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -3539,12 +3606,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 7
+                    "y": 28
                   },
                   "id": 136,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -3555,14 +3627,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Inactive_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Inactive_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Inactive - Memory which has been less recently used.  It is more eligible to be reclaimed for other purposes",
@@ -3574,7 +3646,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Active_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Active_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Active - Memory that has been used more recently and usually not reclaimed unless absolutely necessary",
@@ -3602,6 +3674,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -3926,12 +3999,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 7
+                    "y": 28
                   },
                   "id": 135,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -3942,14 +4020,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Committed_AS_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Committed_AS_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Committed_AS - Amount of memory presently allocated on the system",
@@ -3961,7 +4039,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_CommitLimit_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_CommitLimit_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "CommitLimit - Amount of  memory currently available to be allocated on the system",
@@ -3989,6 +4067,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -4294,12 +4373,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 17
+                    "y": 38
                   },
                   "id": 191,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -4310,14 +4394,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Inactive_file_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Inactive_file_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -4330,7 +4414,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Inactive_anon_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Inactive_anon_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -4343,7 +4427,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Active_file_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Active_file_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -4356,7 +4440,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Active_anon_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Active_anon_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -4385,6 +4469,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -4720,12 +4805,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 17
+                    "y": 38
                   },
                   "id": 130,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -4735,14 +4825,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Writeback_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Writeback_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Writeback - Memory which is actively being written back to disk",
@@ -4754,7 +4844,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_WritebackTmp_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_WritebackTmp_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "WritebackTmp - Memory used by FUSE for temporary writeback buffers",
@@ -4766,7 +4856,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Dirty_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Dirty_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Dirty - Memory which is waiting to get written back to the disk",
@@ -4794,6 +4884,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -4826,7 +4917,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -5122,12 +5214,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 27
+                    "y": 48
                   },
                   "id": 138,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -5138,14 +5235,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Mapped_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Mapped_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Mapped - Used memory in mapped pages files which have been mapped, such as libraries",
@@ -5157,7 +5254,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Shmem_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Shmem_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Shmem - Used shared memory (shared between several processes, thus including RAM disks)",
@@ -5169,7 +5266,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_ShmemHugePages_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_ShmemHugePages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -5182,7 +5279,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_ShmemPmdMapped_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_ShmemPmdMapped_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -5211,6 +5308,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -5243,7 +5341,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -5515,12 +5614,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 27
+                    "y": 48
                   },
                   "id": 160,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -5531,14 +5635,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_KernelStack_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_KernelStack_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "KernelStack - Kernel memory stack. This is not reclaimable",
@@ -5550,7 +5654,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_Percpu_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_Percpu_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -5579,6 +5683,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -5611,7 +5716,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -5898,12 +6004,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 37
+                    "y": 58
                   },
                   "id": 70,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -5913,14 +6024,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_VmallocChunk_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_VmallocChunk_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -5933,7 +6044,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_VmallocTotal_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_VmallocTotal_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -5946,7 +6057,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_VmallocUsed_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_VmallocUsed_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -5975,6 +6086,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -6007,7 +6119,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -6306,12 +6419,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 37
+                    "y": 58
                   },
                   "id": 129,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -6321,14 +6439,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_AnonHugePages_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_AnonHugePages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "AnonHugePages - Memory in anonymous huge pages",
@@ -6340,7 +6458,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_AnonPages_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_AnonPages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "AnonPages - Memory in user pages not backed by files",
@@ -6368,6 +6486,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -6400,7 +6519,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -6702,12 +6822,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 47
+                    "y": 68
                   },
                   "id": 132,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -6717,14 +6842,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_memory_NFS_Unstable_bytes{instance=~\"$ip\"}",
+                      "expr": "node_memory_NFS_Unstable_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet committed to the storage",
@@ -6752,6 +6877,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -6784,7 +6910,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -7086,12 +7213,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 47
+                    "y": 68
                   },
                   "id": 307,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -7101,14 +7233,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_oom_kill{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_oom_kill{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -7137,6 +7269,7 @@ resources:
                         "axisLabel": "pages out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -7168,7 +7301,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -7197,12 +7331,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 57
+                    "y": 78
                   },
                   "id": 176,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -7212,14 +7351,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_pgpgin{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_pgpgin{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Pagesin - Page in operations",
@@ -7231,7 +7370,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_pgpgout{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_pgpgout{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Pagesout - Page out operations",
@@ -7259,6 +7398,7 @@ resources:
                         "axisLabel": "faults",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -7291,7 +7431,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -7582,12 +7723,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 57
+                    "y": 78
                   },
                   "id": 175,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -7598,14 +7744,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Pgfault - Page major and minor fault operations",
@@ -7617,7 +7763,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Pgmajfault - Major page fault operations",
@@ -7629,7 +7775,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])  - irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])  - irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Pgminfault - Minor page fault operations",
@@ -7641,24 +7787,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "Memory",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -7685,6 +7818,7 @@ resources:
                         "axisLabel": "IO read (-) / write (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -7716,7 +7850,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -8045,12 +8180,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 13
+                    "y": 29
                   },
                   "id": 9,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -8060,14 +8200,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - Reads completed",
                       "refId": "A",
@@ -8078,7 +8218,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Writes completed",
                       "refId": "B",
@@ -8106,6 +8246,7 @@ resources:
                         "axisLabel": "bytes read (-) / write (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -8137,7 +8278,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -8466,12 +8608,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 13
+                    "y": 29
                   },
                   "id": 33,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -8481,14 +8628,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - Read bytes",
@@ -8500,7 +8647,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Written bytes",
@@ -8529,6 +8676,7 @@ resources:
                         "axisLabel": "time. read (-) / write (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -8560,7 +8708,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -8889,12 +9038,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 23
+                    "y": 39
                   },
                   "id": 37,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -8904,14 +9058,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_read_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_read_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "hide": false,
                       "interval": "",
                       "intervalFactor": 4,
@@ -8924,7 +9078,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_write_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_write_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "hide": false,
                       "interval": "",
                       "intervalFactor": 1,
@@ -8954,6 +9108,7 @@ resources:
                         "axisLabel": "aqu-sz",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -8986,7 +9141,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -9303,12 +9459,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 23
+                    "y": 39
                   },
                   "id": 35,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -9318,14 +9479,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_io_time_weighted_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_io_time_weighted_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}}",
@@ -9348,11 +9509,13 @@ resources:
                         "mode": "palette-classic"
                       },
                       "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "I/Os",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -9361,6 +9524,7 @@ resources:
                           "tooltip": false,
                           "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "smooth",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -9383,7 +9547,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -9712,12 +9877,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 33
+                    "y": 49
                   },
                   "id": 133,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -9727,14 +9897,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_reads_merged_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_reads_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Read merged",
                       "refId": "A",
@@ -9745,7 +9915,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_writes_merged_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_writes_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Write merged",
                       "refId": "B",
@@ -9767,11 +9937,13 @@ resources:
                         "mode": "palette-classic"
                       },
                       "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "%util",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -9780,6 +9952,7 @@ resources:
                           "tooltip": false,
                           "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "smooth",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -9803,7 +9976,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -10120,12 +10294,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 33
+                    "y": 49
                   },
                   "id": 36,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -10135,14 +10314,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - IO",
@@ -10154,7 +10333,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_discard_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_discard_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - discard",
@@ -10177,11 +10356,13 @@ resources:
                         "mode": "palette-classic"
                       },
                       "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "Outstanding req.",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -10190,6 +10371,7 @@ resources:
                           "tooltip": false,
                           "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "smooth",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -10213,7 +10395,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -10530,12 +10713,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 43
+                    "y": 59
                   },
                   "id": 34,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -10545,14 +10733,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_disk_io_now{instance=~\"$ip\"}",
+                      "expr": "node_disk_io_now{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - IO now",
@@ -10575,11 +10763,13 @@ resources:
                         "mode": "palette-classic"
                       },
                       "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "IOs",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -10588,6 +10778,7 @@ resources:
                           "tooltip": false,
                           "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "smooth",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -10610,7 +10801,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -10927,12 +11119,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 43
+                    "y": 59
                   },
                   "id": 301,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -10942,14 +11139,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_discards_completed_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_discards_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 4,
                       "legendFormat": "{{device}} - Discards completed",
@@ -10961,7 +11158,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_disk_discards_merged_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_disk_discards_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Discards merged",
@@ -10973,24 +11170,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "Storage Disk",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -11017,6 +11201,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11049,7 +11234,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11065,12 +11251,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 14
+                    "y": 30
                   },
                   "id": 43,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11080,14 +11271,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -11101,7 +11292,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_free_bytes{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_free_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": true,
                       "intervalFactor": 1,
@@ -11114,7 +11305,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": true,
                       "intervalFactor": 1,
@@ -11144,6 +11335,7 @@ resources:
                         "axisLabel": "file nodes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11176,7 +11368,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11192,12 +11385,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 14
+                    "y": 30
                   },
                   "id": 41,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11207,14 +11405,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_files_free{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_files_free{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -11244,6 +11442,7 @@ resources:
                         "axisLabel": "files",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11276,7 +11475,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11292,12 +11492,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 24
+                    "y": 40
                   },
                   "id": 28,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11307,14 +11512,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filefd_maximum{instance=~\"$ip\"}",
+                      "expr": "node_filefd_maximum{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 4,
                       "legendFormat": "Max open files",
@@ -11326,7 +11531,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filefd_allocated{instance=~\"$ip\"}",
+                      "expr": "node_filefd_allocated{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Open files",
@@ -11355,6 +11560,7 @@ resources:
                         "axisLabel": "file Nodes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11387,7 +11593,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11403,12 +11610,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 24
+                    "y": 40
                   },
                   "id": 219,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11418,14 +11630,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_files{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_files{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -11449,11 +11661,13 @@ resources:
                         "mode": "palette-classic"
                       },
                       "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11462,6 +11676,7 @@ resources:
                           "tooltip": false,
                           "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "smooth",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -11486,7 +11701,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11518,12 +11734,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 34
+                    "y": 50
                   },
                   "id": 44,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -11533,14 +11754,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_readonly{instance=~\"$ip\",device!~'rootfs'}",
+                      "expr": "node_filesystem_readonly{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{mountpoint}} - ReadOnly",
@@ -11552,7 +11773,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_filesystem_device_error{instance=~\"$ip\",device!~'rootfs',fstype!~'tmpfs'}",
+                      "expr": "node_filesystem_device_error{instance=~\"$ip\",device!~'rootfs',fstype!~'tmpfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -11565,24 +11786,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "Storage Filesystem",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -11608,6 +11816,7 @@ resources:
                         "axisLabel": "packets out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11639,7 +11848,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11728,12 +11938,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 11
+                    "y": 1258
                   },
                   "id": 60,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -11744,14 +11959,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_receive_packets_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_receive_packets_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -11764,7 +11979,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_transmit_packets_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_transmit_packets_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -11793,6 +12008,7 @@ resources:
                         "axisLabel": "packets out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11824,7 +12040,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11853,12 +12070,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 11
+                    "y": 1258
                   },
                   "id": 142,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -11869,14 +12091,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_receive_errs_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_receive_errs_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Receive errors",
@@ -11888,7 +12110,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_transmit_errs_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_transmit_errs_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Transmit errors",
@@ -11916,6 +12138,7 @@ resources:
                         "axisLabel": "packets out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -11947,7 +12170,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -11976,12 +12200,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 21
+                    "y": 1358
                   },
                   "id": 143,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -11992,14 +12221,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_receive_drop_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_receive_drop_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Receive drop",
@@ -12011,7 +12240,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_network_transmit_drop_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_network_transmit_drop_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{device}} - Transmit drop",
@@ -12039,6 +12268,7 @@ resources:
                         "axisLabel": "entries",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12071,7 +12301,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12107,12 +12338,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 21
+                    "y": 1358
                   },
                   "id": 61,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12122,14 +12358,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_nf_conntrack_entries{instance=~\"$ip\"}",
+                      "expr": "node_nf_conntrack_entries{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "NF conntrack entries",
@@ -12141,7 +12377,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_nf_conntrack_entries_limit{instance=~\"$ip\"}",
+                      "expr": "node_nf_conntrack_entries_limit{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "NF conntrack limit",
@@ -12169,6 +12405,7 @@ resources:
                         "axisLabel": "bytes",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12202,7 +12439,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12218,12 +12456,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 31
+                    "y": 1368
                   },
                   "id": 280,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12233,14 +12476,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_network_speed_bytes{instance=~\"$ip\"}",
+                      "expr": "node_network_speed_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{ device }} - Speed",
@@ -12268,6 +12511,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12299,7 +12543,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12315,12 +12560,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 31
+                    "y": 1368
                   },
                   "id": 309,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true,
@@ -12331,14 +12581,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_network_up{operstate=\"up\",instance=~\"$ip\"}",
+                      "expr": "node_network_up{operstate=\"up\",instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "{{interface}} - Operational state UP",
@@ -12350,7 +12600,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_network_carrier{instance=~\"$ip\"}",
+                      "expr": "node_network_carrier{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "instant": false,
                       "legendFormat": "{{device}} - Physical link state",
@@ -12361,24 +12611,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "Network Traffic",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -12405,6 +12642,7 @@ resources:
                         "axisLabel": "datagrams out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12436,7 +12674,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12477,12 +12716,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 12
+                    "y": 1259
                   },
                   "id": 55,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12492,14 +12736,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_InDatagrams{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_InDatagrams{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12512,7 +12756,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_OutDatagrams{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_OutDatagrams{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12541,6 +12785,7 @@ resources:
                         "axisLabel": "datagrams",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12572,7 +12817,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12588,12 +12834,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 12
+                    "y": 1259
                   },
                   "id": 109,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12603,14 +12854,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_InErrors{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_InErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12623,7 +12874,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_NoPorts{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_NoPorts{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12636,7 +12887,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_UdpLite_InErrors{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_UdpLite_InErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "legendFormat": "InErrors Lite - UDPLite Datagrams that could not be delivered to an application",
                       "refId": "C"
@@ -12646,7 +12897,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_RcvbufErrors{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_RcvbufErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12659,7 +12910,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Udp_SndbufErrors{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Udp_SndbufErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12688,6 +12939,7 @@ resources:
                         "axisLabel": "datagrams out (-) / in (+)",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12719,7 +12971,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12760,12 +13013,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 22
+                    "y": 1329
                   },
                   "id": 299,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12775,14 +13033,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_InSegs{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_InSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "instant": false,
                       "interval": "",
@@ -12796,7 +13054,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_OutSegs{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_OutSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12826,6 +13084,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -12858,7 +13117,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -12874,12 +13134,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 22
+                    "y": 1329
                   },
                   "id": 104,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -12889,14 +13154,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_TcpExt_ListenOverflows{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_TcpExt_ListenOverflows{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -12910,7 +13175,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_TcpExt_ListenDrops{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_TcpExt_ListenDrops{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -12924,7 +13189,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -12937,7 +13202,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_RetransSegs{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_RetransSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "legendFormat": "RetransSegs - Segments retransmitted - that is, the number of TCP segments transmitted containing one or more previously transmitted octets",
                       "refId": "D"
@@ -12947,7 +13212,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_InErrs{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_InErrs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "legendFormat": "InErrs - Segments received in error (e.g., bad TCP checksums)",
                       "refId": "E"
@@ -12957,7 +13222,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_OutRsts{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_OutRsts{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "interval": "",
                       "legendFormat": "OutRsts - Segments sent with RST flag",
                       "refId": "F"
@@ -12968,7 +13233,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "irate(node_netstat_TcpExt_TCPRcvQDrop{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_TcpExt_TCPRcvQDrop{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "hide": false,
                       "interval": "",
                       "legendFormat": "TCPRcvQDrop - Packets meant to be queued in rcv queue but dropped because socket rcvbuf limit hit",
@@ -12981,7 +13246,7 @@ resources:
                         "uid": "VictoriaMetrics"
                       },
                       "editorMode": "code",
-                      "expr": "irate(node_netstat_TcpExt_TCPOFOQueue{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_TcpExt_TCPOFOQueue{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "hide": false,
                       "interval": "",
                       "legendFormat": "TCPOFOQueue - TCP layer receives an out of order packet and has enough memory to queue it",
@@ -13009,6 +13274,7 @@ resources:
                         "axisLabel": "connections",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13041,7 +13307,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13077,12 +13344,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 32
+                    "y": 1339
                   },
                   "id": 85,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13092,14 +13364,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_netstat_Tcp_CurrEstab{instance=~\"$ip\"}",
+                      "expr": "node_netstat_Tcp_CurrEstab{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -13113,7 +13385,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_netstat_Tcp_MaxConn{instance=~\"$ip\"}",
+                      "expr": "node_netstat_Tcp_MaxConn{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -13143,6 +13415,7 @@ resources:
                         "axisLabel": "connections",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13175,7 +13448,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13191,12 +13465,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 32
+                    "y": 1339
                   },
                   "id": 82,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13206,14 +13485,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -13226,7 +13505,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -13239,24 +13518,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "Network Netstat",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -13282,6 +13548,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13314,7 +13581,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13330,12 +13598,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 13
+                    "y": 1260
                   },
                   "id": 8,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13345,14 +13618,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_context_switches_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_context_switches_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Context switches",
@@ -13364,7 +13637,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_intr_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_intr_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "intervalFactor": 1,
@@ -13393,6 +13666,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13425,7 +13699,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13441,12 +13716,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 13
+                    "y": 1260
                   },
                   "id": 7,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13456,14 +13736,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_load1{instance=~\"$ip\"}",
+                      "expr": "node_load1{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 4,
                       "legendFormat": "Load 1m",
@@ -13475,7 +13755,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_load5{instance=~\"$ip\"}",
+                      "expr": "node_load5{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 4,
                       "legendFormat": "Load 5m",
@@ -13487,7 +13767,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_load15{instance=~\"$ip\"}",
+                      "expr": "node_load15{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 4,
                       "legendFormat": "Load 15m",
@@ -13515,6 +13795,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13547,7 +13828,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13563,12 +13845,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 23
+                    "y": 1290
                   },
                   "id": 151,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13578,14 +13865,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_entropy_available_bits{instance=~\"$ip\"}",
+                      "expr": "node_entropy_available_bits{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "intervalFactor": 1,
                       "legendFormat": "Entropy available to random number generators",
@@ -13614,6 +13901,7 @@ resources:
                         "axisLabel": "",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13646,7 +13934,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13723,12 +14012,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 23
+                    "y": 1290
                   },
                   "id": 322,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13738,7 +14032,7 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
@@ -13835,6 +14129,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13867,7 +14162,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -13903,12 +14199,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 33
+                    "y": 1300
                   },
                   "id": 64,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -13918,7 +14219,7 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
@@ -13965,6 +14266,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -13996,7 +14298,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14012,12 +14315,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 33
+                    "y": 1300
                   },
                   "id": 306,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14027,14 +14335,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(node_schedstat_timeslices_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(node_schedstat_timeslices_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14063,6 +14371,7 @@ resources:
                         "axisLabel": "seconds",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -14094,7 +14403,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14110,12 +14420,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 43
+                    "y": 1310
                   },
                   "id": 308,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14125,14 +14440,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "irate(process_cpu_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
+                      "expr": "irate(process_cpu_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14145,24 +14460,11 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "System Misc",
               "type": "row"
             },
             {
               "collapsed": true,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "000000001"
-              },
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -14189,6 +14491,7 @@ resources:
                         "axisLabel": "seconds",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -14220,7 +14523,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14252,12 +14556,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 14
+                    "y": 233
                   },
                   "id": 260,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14267,14 +14576,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_estimated_error_seconds{instance=~\"$ip\"}",
+                      "expr": "node_timex_estimated_error_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -14288,7 +14597,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_offset_seconds{instance=~\"$ip\"}",
+                      "expr": "node_timex_offset_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -14302,7 +14611,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_maxerror_seconds{instance=~\"$ip\"}",
+                      "expr": "node_timex_maxerror_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "hide": false,
                       "interval": "",
@@ -14333,6 +14642,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -14364,7 +14674,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14380,12 +14691,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 14
+                    "y": 233
                   },
                   "id": 291,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14395,14 +14711,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_loop_time_constant{instance=~\"$ip\"}",
+                      "expr": "node_timex_loop_time_constant{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14432,6 +14748,7 @@ resources:
                         "axisLabel": "counter",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -14463,7 +14780,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14495,12 +14813,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 0,
-                    "y": 24
+                    "y": 243
                   },
                   "id": 168,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14510,14 +14833,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_sync_status{instance=~\"$ip\"}",
+                      "expr": "node_timex_sync_status{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14530,7 +14853,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_frequency_adjustment_ratio{instance=~\"$ip\"}",
+                      "expr": "node_timex_frequency_adjustment_ratio{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14560,6 +14883,7 @@ resources:
                         "axisLabel": "seconds",
                         "axisPlacement": "auto",
                         "barAlignment": 0,
+                        "barWidthFactor": 0.6,
                         "drawStyle": "line",
                         "fillOpacity": 20,
                         "gradientMode": "opacity",
@@ -14591,7 +14915,8 @@ resources:
                         "mode": "absolute",
                         "steps": [
                           {
-                            "color": "green"
+                            "color": "green",
+                            "value": null
                           },
                           {
                             "color": "red",
@@ -14607,12 +14932,17 @@ resources:
                     "h": 10,
                     "w": 12,
                     "x": 12,
-                    "y": 24
+                    "y": 243
                   },
                   "id": 294,
                   "options": {
                     "legend": {
-                      "calcs": ["mean", "lastNotNull", "max", "min"],
+                      "calcs": [
+                        "mean",
+                        "lastNotNull",
+                        "max",
+                        "min"
+                      ],
                       "displayMode": "table",
                       "placement": "bottom",
                       "showLegend": true
@@ -14622,14 +14952,14 @@ resources:
                       "sort": "none"
                     }
                   },
-                  "pluginVersion": "9.2.0",
+                  "pluginVersion": "11.4.0",
                   "targets": [
                     {
                       "datasource": {
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_tick_seconds{instance=~\"$ip\"}",
+                      "expr": "node_timex_tick_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14642,7 +14972,7 @@ resources:
                         "type": "prometheus",
                         "uid": "VictoriaMetrics"
                       },
-                      "expr": "node_timex_tai_offset_seconds{instance=~\"$ip\"}",
+                      "expr": "node_timex_tai_offset_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
                       "format": "time_series",
                       "interval": "",
                       "intervalFactor": 1,
@@ -14655,28 +14985,20 @@ resources:
                   "type": "timeseries"
                 }
               ],
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "000000001"
-                  },
-                  "refId": "A"
-                }
-              ],
               "title": "System Timesync",
               "type": "row"
             }
           ],
+          "preload": false,
           "refresh": "",
-          "revision": 1,
-          "schemaVersion": 39,
-          "tags": ["worker-stats"],
+          "schemaVersion": 40,
+          "tags": [
+            "worker-stats"
+          ],
           "templating": {
             "list": [
               {
                 "current": {
-                  "selected": true,
                   "text": "worker-0",
                   "value": "worker-0"
                 },
@@ -14685,11 +15007,9 @@ resources:
                   "uid": "VictoriaMetrics"
                 },
                 "definition": "label_values(kube_pod_info,pod)",
-                "hide": 0,
+                "description": "Select one worker to check it's detailed stats in panels.",
                 "includeAll": false,
                 "label": "Worker",
-                "description": "Select one worker to check it's detailed stats in panels.",
-                "multi": false,
                 "name": "worker",
                 "options": [],
                 "query": {
@@ -14699,15 +15019,14 @@ resources:
                 },
                 "refresh": 1,
                 "regex": "^worker.*",
-                "skipUrlSync": false,
-                "sort": 0,
                 "type": "query"
               },
               {
                 "current": {
-                  "selected": true,
-                  "text": ["All"],
-                  "value": ["$__all"]
+                  "text": "All",
+                  "value": [
+                    "$__all"
+                  ]
                 },
                 "datasource": {
                   "type": "prometheus",
@@ -14727,22 +15046,16 @@ resources:
                 },
                 "refresh": 2,
                 "regex": "",
-                "skipUrlSync": false,
                 "sort": 3,
-                "tagValuesQuery": "",
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
               },
               {
                 "current": {
-                  "selected": false,
                   "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
                   "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
                 },
                 "hide": 2,
                 "includeAll": false,
-                "multi": false,
                 "name": "diskdevices",
                 "options": [
                   {
@@ -14752,14 +15065,14 @@ resources:
                   }
                 ],
                 "query": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
-                "skipUrlSync": false,
                 "type": "custom"
               },
               {
                 "current": {
-                  "selected": true,
-                  "text": ["All"],
-                  "value": ["$__all"]
+                  "text": "All",
+                  "value": [
+                    "$__all"
+                  ]
                 },
                 "datasource": {
                   "type": "prometheus",
@@ -14778,8 +15091,6 @@ resources:
                 },
                 "refresh": 1,
                 "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
                 "type": "query"
               }
             ]
@@ -14788,23 +15099,9 @@ resources:
             "from": "now-2d",
             "to": "now"
           },
-          "timepicker": {
-            "refresh_intervals": [
-              "5s",
-              "10s",
-              "30s",
-              "1m",
-              "5m",
-              "15m",
-              "30m",
-              "1h",
-              "2h",
-              "1d"
-            ],
-            "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
-          },
+          "timepicker": {},
           "timezone": "browser",
           "title": "Workers Detailed Stats",
-          "version": 22,
+          "version": 2,
           "weekStart": ""
         }


### PR DESCRIPTION
## Workers Detailed Stats changes

Changes make panels worker **and** node specific (new, old):
<img width="1500" alt="Screenshot 2025-05-27 at 16 19 55" src="https://github.com/user-attachments/assets/9b18eae0-8d0c-446d-8901-bf10dd54a1fa" />

It would previously show stats from all nodes that the selected worker was scheduled on during the selected window of time.

## Jobs Overview changes

A new row with per worker stats (similar to Workers Overview dahsboard) is added, this helps when users are looking for outliers among many workers of a job, or when variance in cluster based metrics are high.